### PR TITLE
Fix the way the form id is obtained to prevent multiple PHP warnings …

### DIFF
--- a/where-is-gf.php
+++ b/where-is-gf.php
@@ -39,7 +39,7 @@ function list_pages_with_gravity_forms() {
 	//build the Where is GF? page output
 	foreach ($forms as $form) {
 
-		$gfFormID = (string)$form['fields']['0']['formId'];
+		$gfFormID = (string)$form['id'];
 
 		// open the paragraph
 		$output .= '<p style="font-size:16px;">';


### PR DESCRIPTION
Instead of getting the form id directly using its property, the plugin is trying to get it from form fields, something that is not needed and causes some notices and warnings. Example:

```
Notice: Undefined offset: 0 in /home/user/www/public_html/wp-content/plugins/where-is-gravity-forms-master/where-is-gf.php on line 42

Notice: Trying to access array offset on value of type null in /home/user/www/public_html/wp-content/plugins/where-is-gravity-forms-master/where-is-gf.php on line 42

Warning: strpos(): Empty needle in /home/user/www/public_html/wp-content/plugins/where-is-gravity-forms-master/where-is-gf.php on line 77

Warning: strpos(): Empty needle in /home/user/www/public_html/wp-content/plugins/where-is-gravity-forms-master/where-is-gf.php on line 77

Warning: strpos(): Empty needle in /home/user/www/public_html/wp-content/plugins/where-is-gravity-forms-master/where-is-gf.php on line 77

Warning: strpos(): Empty needle in /home/user/www/public_html/wp-content/plugins/where-is-gravity-forms-master/where-is-gf.php on line 77

Warning: strpos(): Empty needle in /home/user/www/public_html/wp-content/plugins/where-is-gravity-forms-master/where-is-gf.php on line 77
```

This PR fix the issue.